### PR TITLE
Store entry point arguments in fibre's own stack (s390x)

### DIFF
--- a/libs/context/src/asm/jump_s390x_sysv_elf_gas.S
+++ b/libs/context/src/asm/jump_s390x_sysv_elf_gas.S
@@ -49,11 +49,12 @@
 .type	jump_fcontext, @function
 
 #define ARG_OFFSET         0
-#define GR_OFFSET	   16
-#define FP_OFFSET	   96
-#define FPC_OFFSET	   160
-#define PC_OFFSET	   168
-#define CONTEXT_SIZE	   176
+#define GR_OFFSET          16
+#define R14_OFFSET         88
+#define FP_OFFSET          96
+#define FPC_OFFSET         160
+#define PC_OFFSET          168
+#define CONTEXT_SIZE       176
 
 #define REG_SAVE_AREA_SIZE 160
 
@@ -131,11 +132,14 @@ jump_fcontext:
 	ltg	%r2,GR_OFFSET(%r15)
 	jnz	use_return_slot
 
-	/* We restore a make_fcontext context.  Use the function
-	   argument slot in the context we just saved and allocate the
-	   register save area for the target function.  */
-	la	%r2,ARG_OFFSET(%r1)
-	aghi	%r15,-REG_SAVE_AREA_SIZE
+	/* We're restoring a context created by make_fcontext.
+	   This is going to be the argument of the entry point
+	   of the fiber. We're placing it on top of the ABI
+	   defined register save area of the fiber's own stack. */
+	la	%r2,REG_SAVE_AREA_SIZE(%r15)
+
+	/* REG_SAVE_AREA_SIZE + sizeof(transfer_t) */
+	aghi	%r15,-(REG_SAVE_AREA_SIZE+16)
 
 use_return_slot:
 	/* Save the two fields in transfer_t.  When calling a

--- a/libs/context/src/asm/make_s390x_sysv_elf_gas.S
+++ b/libs/context/src/asm/make_s390x_sysv_elf_gas.S
@@ -49,12 +49,12 @@
 .type	make_fcontext, @function
 
 #define ARG_OFFSET         0
-#define GR_OFFSET	   16
-#define R14_OFFSET	   88
-#define FP_OFFSET	   96
-#define FPC_OFFSET	   160
-#define PC_OFFSET	   168
-#define CONTEXT_SIZE	   176
+#define GR_OFFSET          16
+#define R14_OFFSET         88
+#define FP_OFFSET          96
+#define FPC_OFFSET         160
+#define PC_OFFSET          168
+#define CONTEXT_SIZE       176
 
 /*
 
@@ -72,7 +72,7 @@ r4 - The address of the context function
 make_fcontext:
 	.machine "z10"
 	/* Align the stack to an 8 byte boundary.  */
-	nill    %r2,0xfff0
+	nill    %r2,0xfff8
 
 	/* Allocate stack space for the context.  */
 	aghi	%r2,-CONTEXT_SIZE

--- a/libs/context/src/asm/ontop_s390x_sysv_elf_gas.S
+++ b/libs/context/src/asm/ontop_s390x_sysv_elf_gas.S
@@ -49,13 +49,12 @@
 .type   ontop_fcontext, @function
 
 #define ARG_OFFSET         0
-#define GR_OFFSET	   16
-#define R14_OFFSET	   88
-#define FP_OFFSET	   96
-#define FPC_OFFSET	   160
-#define PC_OFFSET	   168
-#define CONTEXT_SIZE	   176
-
+#define GR_OFFSET          16
+#define R14_OFFSET         88
+#define FP_OFFSET          96
+#define FPC_OFFSET         160
+#define PC_OFFSET          168
+#define CONTEXT_SIZE       176
 
 /*
 


### PR DESCRIPTION
This is a backport of changes from https://github.com/boostorg/context/pull/224 and https://github.com/boostorg/context/pull/226. The issue they aim to resolve only exists on IBM Z / s390x.

In the current implementation fibres spawned by other fibres or threads would have the argument of their entry point (`void fiber_entry( transfer_t t)`) be allocated on the stack of their parent, which would then cause segmentation fault if the former outlived the latter.

The x86-64 implementation (`x86_64_sysv_elf` is the combination I tested) supports this use-case, so this change means to achieve feature parity for the s390x implementation in this regard by storing the aforementioned argument in the fibre's own stack.