### PR TITLE
Addressing fix for: Clickhouse crash issue on power pc build

### DIFF
--- a/libs/context/src/asm/jump_ppc64_sysv_elf_gas.S
+++ b/libs/context/src/asm/jump_ppc64_sysv_elf_gas.S
@@ -97,7 +97,7 @@ jump_fcontext:
 # endif
 #endif
     # reserve space on stack
-    subi  %r1, %r1, 184
+    subi  %r1, %r1, 200
 
 #if _CALL_ELF != 2
     std  %r2,  0(%r1)  # save TOC
@@ -133,6 +133,10 @@ jump_fcontext:
     # save LR as PC
     std   %r0, 176(%r1)
 
+    # save VS63
+    li %r31, 184
+    stvx %v31, %r1, %r31
+
     # store RSP (pointing to context-data) in R6
     mr  %r6, %r1
 
@@ -145,6 +149,11 @@ jump_fcontext:
 
     ld  %r2,  0(%r1)  # restore TOC
 #endif
+
+    # restore VS63
+    li %r31, 184
+    lvx %v31, %r1, %r31
+
     ld  %r14, 8(%r1)  # restore R14
     ld  %r15, 16(%r1)  # restore R15
     ld  %r16, 24(%r1)  # restore R16
@@ -180,7 +189,7 @@ jump_fcontext:
     mtctr  %r12
 
     # adjust stack
-    addi  %r1, %r1, 184
+    addi  %r1, %r1, 200
 
 #if _CALL_ELF == 2
     # copy transfer_t into transfer_fn arg registers

--- a/libs/context/src/asm/ontop_ppc64_sysv_elf_gas.S
+++ b/libs/context/src/asm/ontop_ppc64_sysv_elf_gas.S
@@ -97,7 +97,7 @@ ontop_fcontext:
 # endif
 #endif
     # reserve space on stack
-    subi  %r1, %r1, 184
+    subi  %r1, %r1, 200
 
 #if _CALL_ELF != 2
     std  %r2,  0(%r1)  # save TOC
@@ -133,6 +133,10 @@ ontop_fcontext:
     # save LR as PC
     std   %r0, 176(%r1)
 
+    # save VS63
+    li %r31, 184
+    stvx %v31, %r1, %r31
+
     # store RSP (pointing to context-data) in R7
     mr  %r7, %r1
 
@@ -143,6 +147,10 @@ ontop_fcontext:
     # restore RSP (pointing to context-data) from R4
     mr  %r1, %r4
 #endif
+
+    # restore VS63
+    li %r31, 184
+    lvx %v31, %r1, %r31
 
     ld  %r14, 8(%r1)  # restore R14
     ld  %r15, 16(%r1)  # restore R15
@@ -203,7 +211,7 @@ return_to_ctx:
     mtlr  %r0
 
     # adjust stack
-    addi  %r1, %r1, 184
+    addi  %r1, %r1, 200
 
     # jump to context
     bctr


### PR DESCRIPTION
ClickHouse power pc build release version crashes by using following SQL(which is essentially functional test 02287_legacy_column_name_of_tuple_literal_over_distributed):

select if(in(dummy, tuple(0, 1)), 'ok', 'ok') from remote('localhost', system.one) settings legacy_column_name_of_tuple_literal=1, prefer_localhost_replica=0;

Note that debug version(with -O0 option to compile) works fine which indicates it could be a compiler optimization issue.

A llvm github issue was created:
https://github.com/llvm/llvm-project/issues/102311

Stack info from core dump:

Core was generated by `../clickhouse18-2 server '.

Program terminated with signal SIGSEGV, Segmentation fault.

#0 std::_1::construct_at[abi:v15000]<DB::ExecutingGraph::Node*, DB::ExecutingGraph::Node*, DB::ExecutingGraph::Node*>(DB::ExecutingGraph::Node, DB::ExecutingGraph::Node&&) (_location=0xfb610150283a0a00, __args=)

at ./contrib/llvm-project/libcxx/include/__memory/construct_at.h:35
35 return ::new (VSTD::voidify(*location)) _Tp(_VSTD::forward<_Args>(_args)...);

[Current thread is 1 (Thread 0x7589b2f29110 (LWP 242663))]

(gdb) bt

#0 std::_1::construct_at[abi:v15000]<DB::ExecutingGraph::Node*, DB::ExecutingGraph::Node*, DB::ExecutingGraph::Node*>(DB::ExecutingGraph::Node, DB::ExecutingGraph::Node&&) (_location=0xfb610150283a0a00, __args=)

at ./contrib/llvm-project/libcxx/include/__memory/construct_at.h:35
{{https://github.com/boostorg/context/issues/1 std::_1::allocator_traits<std::1::allocatorDB::ExecutingGraph::Node* >::construct[abi:v15000]<DB::ExecutingGraph::Node*, DB::ExecutingGraph::Node*, void, void>(std::1::allocatorDB::ExecutingGraph::Node*&, DB::ExecutingGraph::Node*, DB::ExecutingGraph::Node&&) (_p=0xfb610150283a0a00, }}

__args=<optimized out>)

at ./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:298
https://github.com/boostorg/context/pull/2 std::_1::deque<DB::ExecutingGraph::Node*, std::_1::allocatorDB::ExecutingGraph::Node* >::push_back (this=0x7589b2f27ec0, __v=)

at ./contrib/llvm-project/libcxx/include/deque:1967
https://github.com/boostorg/context/pull/3 std::_1::queue<DB::ExecutingGraph::Node*, std::1::deque<DB::ExecutingGraph::Node*, std::_1::allocatorDB::ExecutingGraph::Node* > >::pushabi:v15000 (this=0x7589b2f27ec0, __v=)

at ./contrib/llvm-project/libcxx/include/queue:365
{{https://github.com/boostorg/context/pull/4 DB::ExecutingGraph::updateNode (this=0x7589b6d41300, pid=0, queue=..., }}

async_queue=...)

at ./ppc18-rel/./src/Processors/Executors/ExecutingGraph.cpp:344
https://github.com/boostorg/context/pull/5 0x0000000022a679ec in DB::PipelineExecutor::executeStepImpl (

this=0x7589b6e78818, thread_num=<optimized out>, yield_flag=0x0)

at ./ppc18-rel/./src/Processors/Executors/PipelineExecutor.cpp:291
-Type for more, q to quit, c to continue without paging-c

https://github.com/boostorg/context/pull/6 0x0000000022a66f0c in DB::PipelineExecutor::executeSingleThread (

this=0x7589b6e78818, thread_num=0)

at ./ppc18-rel/./src/Processors/Executors/PipelineExecutor.cpp:238
{{https://github.com/boostorg/context/pull/7 DB::PipelineExecutor::executeImpl (this=0x7589b6e78818, }}

num_threads=<optimized out>, concurrency_control=<optimized out>)

at ./ppc18-rel/./src/Processors/Executors/PipelineExecutor.cpp:410
{{https://github.com/boostorg/context/pull/8 0x0000000022a66bf4 in DB::PipelineExecutor::execute (this=0x7589b6e78818, }}

num_threads=1, concurrency_control=<optimized out>)

at ./ppc18-rel/./src/Processors/Executors/PipelineExecutor.cpp:110
{{https://github.com/boostorg/context/pull/9 0x0000000022a76684 in DB::threadFunction (data=..., thread_group=..., }}

{{ num_threads=1, }}

concurrency_control=<error reading variable: Unable to access DWARF register number 73>)

at ./ppc18-rel/./src/Processors/Executors/PullingAsyncPipelineExecutor.cpp:83
https://github.com/boostorg/context/pull/10 DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0::operator()() const (this=)

at ./ppc18-rel/./src/Processors/Executors/PullingAsyncPipelineExecutor.cpp:109
https://github.com/boostorg/context/pull/11 std::_1::invoke[abi:v15000]<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&) (_f=...)

at ./contrib/llvm-project/libcxx/include/__functional/invoke.h:394
https://github.com/boostorg/context/pull/12 ZNSt3118apply_tuple_implB6v15000IRZN2DB28PullingAsyncPipelineExecutor4pullERNS1_5ChunkEmE3$_0RNS_5tupleIJEEETpTnmJEEEDcOT_OT0_NS_15tuple_indicesIJXspT1_EEEE (_f=..., __t=...) at ./contrib/llvm-project/libcxx/include/tuple:1789

https://github.com/boostorg/context/pull/13 std::_1::apply[abi:v15000]<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&, std::1::tuple<>&>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&, std::1::tuple<>&) (_f=..., __t=...)

at ./contrib/llvm-project/libcxx/include/tuple:1798
https://github.com/boostorg/context/issues/14 ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::{lambda()https://github.com/boostorg/context/issues/1}::operator()() (this=) at ./src/Common/ThreadPool.h:251

https://github.com/boostorg/context/issues/15 std::_1::invoke[abi:v15000]<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::{lambda()https://github.com/boostorg/context/issues/1}&>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&) (_f=...)

at ./contrib/llvm-project/libcxx/include/__functional/invoke.h:394
https://github.com/boostorg/context/issues/16 std::_1::invoke_void_return_wrapper<void, true>::call<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::{lambda()https://github.com/boostorg/context/issues/1}&>(ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::{lambda()https://github.com/boostorg/context/issues/1}&) (_args=...)

at ./contrib/llvm-project/libcxx/include/__functional/invoke.h:479
https://github.com/boostorg/context/issues/17 std::_1::function::_default_alloc_func<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::{lambda()https://github.com/boostorg/context/issues/1}, void ()>::operator()[abi:v15000](https://github.com/boostorg/context/pull/267) (

this=<optimized out>)

at ./contrib/llvm-project/libcxx/include/__functional/function.h:235
https://github.com/boostorg/context/pull/18 std::_1::function::policy_invoker<void ()>::call_impl<std::1::function::default_alloc_func<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::{lambda()https://github.com/boostorg/context/issues/1}, void ()> >(std::1::function::_policy_storage const*) (

__buf=<optimized out>)

at ./contrib/llvm-project/libcxx/include/__functional/function.h:716
https://github.com/boostorg/context/pull/19 0x000000001ad68d4c in std::_1::function::_policy_func<void ()>::operator()[abi:v15000](https://github.com/boostorg/context/pull/267) const (this=0x7589b2f28570)

at ./contrib/llvm-project/libcxx/include/__functional/function.h:848
https://github.com/boostorg/context/pull/20 std::__1::function<void()>::operator() (this=0x7589b2f28570)

at ./contrib/llvm-project/libcxx/include/__functional/function.h:1187
{{https://github.com/boostorg/context/pull/21 ThreadPoolImplstd::__1::thread::worker (this=0x758b92e42e40, }}

thread_it=...) at ./ppc18-rel/./src/Common/ThreadPool.cpp:462
https://github.com/boostorg/context/pull/22 0x000000001ad6def4 in ThreadPoolImplstd::_1::thread::scheduleImpl(std::1::function<void ()>, Priority, std::_1::optional, bool)::{lambda()https://github.com/boostorg/context/pull/2}::operator()() const (this=0x758b064491a8)

at ./ppc18-rel/./src/Common/ThreadPool.cpp:219
https://github.com/boostorg/context/issues/23 std::_1::invoke[abi:v15000]<ThreadPoolImplstd::1::thread::scheduleImpl(std::1::function<void ()>, Priority, std::1::optional, bool)::{lambda()https://github.com/boostorg/context/pull/2}>(ThreadPoolImplstd::1::thread::scheduleImpl(std::1::function<void ()>, Priority, std::1::optional, bool)::{lambda()https://github.com/boostorg/context/pull/2}&&) (_f=...)

at ./contrib/llvm-project/libcxx/include/__functional/invoke.h:394
https://github.com/boostorg/context/issues/24 ZNSt3116thread_executeB6v15000INS_10unique_ptrINS_15thread_structENS_14default_deleteIS2_EEEEZN14ThreadPoolImplINS_6threadEE12scheduleImplIvEET_NS_8functionIFvvEEE8PriorityNS_8optionalImEEbEUlvE0_JETpTnmJEEEvRNS_5tupleIJSA_T0_DpT1_EEENS_15tuple_indicesIJXspT2_EEEE (_t=...)

at ./contrib/llvm-project/libcxx/include/thread:284
https://github.com/boostorg/context/pull/25 std::_1::thread_proxy[abi:v15000]<std::1::tuple<std::1::unique_ptr<std::1::thread_struct, std::1::default_deletestd::1::thread_struct >, ThreadPoolImplstd::1::thread::scheduleImpl(std::1::function<void ()>, Priority, std::_1::optional, bool)::{lambda()https://github.com/boostorg/context/pull/2}> >(void*) (

__vp=0x758b064491a0) at ./contrib/llvm-project/libcxx/include/thread:295
https://github.com/boostorg/context/pull/26 0x0000758b93ce8838 in start_thread ()

from /lib/powerpc64le-linux-gnu/libpthread.so.0

https://github.com/boostorg/context/pull/27 0x0000758b93beba44 in clone () from /lib/powerpc64le-linux-gnu/libc.so.6