### PR TITLE
Fix naming conflict with illumos's regset.h.

### DIFF
--- a/boost/geometry/strategies/line_interpolate/cartesian.hpp
+++ b/boost/geometry/strategies/line_interpolate/cartesian.hpp
@@ -56,10 +56,10 @@ struct default_strategy<Geometry, cartesian_tag>
 };
 
 
-template <typename CT, typename DS>
-struct strategy_converter<strategy::line_interpolate::cartesian<CT, DS> >
+template <typename CT, typename DST>
+struct strategy_converter<strategy::line_interpolate::cartesian<CT, DST> >
 {
-    static auto get(strategy::line_interpolate::cartesian<CT, DS> const&)
+    static auto get(strategy::line_interpolate::cartesian<CT, DST> const&)
     {
         return strategies::line_interpolate::cartesian<CT>();
     }

--- a/boost/geometry/strategies/line_interpolate/spherical.hpp
+++ b/boost/geometry/strategies/line_interpolate/spherical.hpp
@@ -72,12 +72,12 @@ struct default_strategy<Geometry, spherical_equatorial_tag>
 };
 
 
-template <typename CT, typename DS>
-struct strategy_converter<strategy::line_interpolate::spherical<CT, DS> >
+template <typename CT, typename DST>
+struct strategy_converter<strategy::line_interpolate::spherical<CT, DST> >
 {
-    static auto get(strategy::line_interpolate::spherical<CT, DS> const& s)
+    static auto get(strategy::line_interpolate::spherical<CT, DST> const& s)
     {
-        typedef typename strategy::line_interpolate::spherical<CT, DS>::radius_type radius_type;
+        typedef typename strategy::line_interpolate::spherical<CT, DST>::radius_type radius_type;
         return strategies::line_interpolate::spherical<radius_type, CT>(s.radius());
     }
 };


### PR DESCRIPTION
Illumos defines a `DS` macro in its regset.h:

https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/intel/sys/regset.h#L111

This conflicts with the DS template parameters used in structs in boost/geometry/strategies/line_interpolate. This patch renames the conflicting DS parameters to avoid the conflict.