### PR TITLE
aarch64: zero the fiber frame-pointer terminator in make_fcontext

### DIFF
--- a/libs/context/src/asm/make_arm64_aapcs_elf_gas.S
+++ b/libs/context/src/asm/make_arm64_aapcs_elf_gas.S
@@ -82,6 +82,13 @@ make_fcontext:
     # reserve space for context-data on context-stack
     sub  x0, x0, #0xb0
 
+    # ClickHouse patch (issue #111579): zero the saved frame-pointer slot (x29, at offset 0x90 of
+    # the context block) so a fiber starts with a null frame-pointer terminator. make_fcontext
+    # otherwise leaves this slot uninitialized; a frame-pointer stack walker then follows the junk
+    # off the fiber stack and can crash. A null terminator makes such walkers stop cleanly at the
+    # fiber entry. (Harmless on Linux, which unwinds via CFI, but keeps the two arm64 backends in sync.)
+    str  xzr, [x0, #0x90]
+
     # third arg of make_fcontext() == address of context-function
     # store address as a PC to jump in
     str  x2, [x0, #0xa0]

--- a/libs/context/src/asm/make_arm64_aapcs_macho_gas.S
+++ b/libs/context/src/asm/make_arm64_aapcs_macho_gas.S
@@ -63,6 +63,13 @@ _make_fcontext:
     ; reserve space for context-data on context-stack
     sub  x0, x0, #0xb0
 
+    ; ClickHouse patch (issue #111579): zero the saved frame-pointer slot (x29, at offset 0x90 of
+    ; the context block) so a fiber starts with a null frame-pointer terminator. make_fcontext
+    ; otherwise leaves this slot uninitialized; a frame-pointer stack walker (macOS backtrace()/
+    ; __thread_stack_pcs, sample, lldb, the crash reporter) then follows the junk off the fiber
+    ; stack and crashes. A null terminator makes such walkers stop cleanly at the fiber entry.
+    str  xzr, [x0, #0x90]
+
     ; third arg of make_fcontext() == address of context-function
     ; store address as a PC to jump in
     str  x2, [x0, #0xa0]


### PR DESCRIPTION
Zero the saved frame-pointer slot in the arm64 `make_fcontext` (both `macho` and `elf`) so a freshly created fiber starts with a **null frame-pointer terminator**.

### Why this is needed

`make_fcontext` initializes a fiber's context block but, on arm64, **never writes the saved frame-pointer (x29) slot** (offset `0x90`) — it only stores the entry PC (`0xa0`) and the `finish` return address (`0x98`). So a fiber's bottom frame inherits whatever junk was in that memory (fiber stacks are not zeroed; e.g. ClickHouse allocates them with `aligned_alloc`).

That is fine for a CFI-based unwinder (libunwind / `_Unwind_Backtrace`), which follows `.cfi`/compact-unwind info and stops at the fiber entry. But a **frame-pointer walker** — Apple's `backtrace()`/`__thread_stack_pcs`, `sample`, `lldb`, the macOS crash reporter — blindly chases the x29 chain, reads that uninitialized terminator, and follows it off the fiber stack. When the junk happens to be an aligned, monotonically-increasing, **unmapped** address, the walk dereferences it and the process dies with `SIGSEGV` in `__thread_stack_pcs`.

This is the macOS crash in ClickHouse#111579: the frame-pointer-based macOS stack capture faulted while the memory profiler sampled an allocation running on a `boost::context` fiber. Forcing the terminator to `0` makes any frame-pointer walker stop cleanly at the fiber entry, exactly like a real thread's bottom frame (`thread_start` leaves fp = 0).

Verified with a standalone reproducer built against this exact asm: unpatched `make_fcontext` → `SIGSEGV` inside `backtrace()`; patched → a clean, complete trace.

### Why arm64 only, not x86_64

x86_64 does **not** have this problem and must **not** get the same change:

- On x86_64 SysV, `make_fcontext` **already initializes** the frame-pointer (rbp) slot — it stores `&finish` there (offset `0x30` on `macho`, `0x38` on `elf`). The terminator is therefore a defined, mapped code address, not junk; a frame-pointer walker reads it without faulting and stops at the alignment check.
- That slot is also **functional** on x86_64: `trampoline` does `push %rbp; jmp *%rbx`, i.e. rbp (= `&finish`) is used as the fiber function's return address. Zeroing it would push `0` and crash on every fiber return.

Only arm64 leaves the frame-pointer slot uninitialized, so the fix is scoped to the two arm64 backends. The `elf` change is a harmless no-op behaviorally on Linux (which unwinds via CFI) and just keeps the two arm64 backends in sync.

### Upstream

Not fixed upstream: current `boostorg/context` `master`/`develop` leave the arm64 fp slot uninitialized as well (they assume CFI-based unwinding). Worth proposing upstream.
